### PR TITLE
Go: DSTU2 jsonformat support

### DIFF
--- a/go/jsonformat/dstu2_utils.go
+++ b/go/jsonformat/dstu2_utils.go
@@ -1,0 +1,65 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonformat
+
+import (
+	"fmt"
+
+	"bitbucket.org/creachadair/stringset"
+	"google.golang.org/protobuf/proto"
+
+	dpb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/datatypes_go_proto"
+	epb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/fhirproto_extensions_go_proto"
+	rpb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/resources_go_proto"
+)
+
+type dstu2Config struct{}
+
+func (c dstu2Config) newEmptyContainedResource() proto.Message {
+	return &rpb.ContainedResource{}
+}
+
+func (c dstu2Config) newBase64BinarySeparatorStride(sep string, stride uint32) proto.Message {
+	return &epb.Base64BinarySeparatorStride{
+		Separator: &dpb.String{Value: sep},
+		Stride:    &dpb.PositiveInt{Value: stride},
+	}
+}
+
+func (c dstu2Config) newPrimitiveHasNoValue(bv bool) proto.Message {
+	return &epb.PrimitiveHasNoValue{
+		ValueBoolean: &dpb.Boolean{Value: bv},
+	}
+}
+
+func (c dstu2Config) noIDFieldTypes() stringset.Set {
+	return stringset.New()
+}
+
+func (c dstu2Config) keysToSkip() stringset.Set {
+	return stringset.New()
+}
+
+// UnmarshalDSTU2 returns the corresponding protobuf message given a serialized FHIR JSON object
+func (u *Unmarshaller) UnmarshalDSTU2(in []byte) (*rpb.ContainedResource, error) {
+	if _, ok := u.cfg.(dstu2Config); !ok {
+		return nil, fmt.Errorf("the unmarshaler is not for FHIR %s", DSTU2)
+	}
+	p, err := u.Unmarshal(in)
+	if err != nil {
+		return nil, err
+	}
+	return p.(*rpb.ContainedResource), nil
+}

--- a/go/jsonformat/marshaller_test.go
+++ b/go/jsonformat/marshaller_test.go
@@ -18,12 +18,13 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/google/fhir/go/jsonformat/internal/jsonpbhelper"
-	"github.com/google/go-cmp/cmp"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/google/fhir/go/jsonformat/internal/jsonpbhelper"
+	"github.com/google/go-cmp/cmp"
 
-	anypb "google.golang.org/protobuf/types/known/anypb"
+	d2pb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/datatypes_go_proto"
+	r2pb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/resources_go_proto"
 	c4pb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/codes_go_proto"
 	d4pb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/datatypes_go_proto"
 	r4pb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/bundle_and_contained_resource_go_proto"
@@ -36,6 +37,7 @@ import (
 	d3pb "github.com/google/fhir/go/proto/google/fhir/proto/stu3/datatypes_go_proto"
 	m3pb "github.com/google/fhir/go/proto/google/fhir/proto/stu3/metadatatypes_go_proto"
 	r3pb "github.com/google/fhir/go/proto/google/fhir/proto/stu3/resources_go_proto"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 )
 
 // TODO: Find a better way to maintain the versioned unit tests.
@@ -66,6 +68,38 @@ func TestMarshalContainedResource(t *testing.T) {
 			name:   "PrimitiveExtension",
 			pretty: true,
 			inputs: []mvr{
+				{
+					ver: DSTU2,
+					r: &r2pb.ContainedResource{
+						OneofResource: &r2pb.ContainedResource_Patient{
+							Patient: &r2pb.Patient{
+								Active: &d2pb.Boolean{
+									Value: true,
+								},
+								Name: []*d2pb.HumanName{{
+									Given: []*d2pb.String{{
+										Value: "Toby",
+										Id: &d2pb.Id{
+											Value: "a3",
+										},
+										Extension: []*d2pb.Extension{{
+											Url: &d2pb.Uri{
+												Value: "http://hl7.org/fhir/StructureDefinition/qualifier",
+											},
+											Value: &d2pb.Extension_ValueX{
+												Choice: &d2pb.Extension_ValueX_Code{
+													Code: &d2pb.Code{
+														Value: "MID",
+													},
+												},
+											},
+										}},
+									}},
+								}},
+							},
+						},
+					},
+				},
 				{
 					ver: STU3,
 					r: &r3pb.ContainedResource{

--- a/go/jsonformat/unmarshaller_test.go
+++ b/go/jsonformat/unmarshaller_test.go
@@ -18,6 +18,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+
+	c2pb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/codes_go_proto"
+	d2pb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/datatypes_go_proto"
+	r2pb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/resources_go_proto"
+
 	"math"
 	"strconv"
 	"strings"
@@ -71,6 +76,38 @@ func TestUnmarshal(t *testing.T) {
 		json  []byte
 		wants []mvr
 	}{
+		{
+			name: "DSTU2 SearchParameter",
+			json: []byte(`
+	{
+      "resourceType": "SearchParameter",
+			"url": "http://example.com/SearchParameter",
+			"name": "Search-parameter",
+			"status": "active",
+			"description": "custom search parameter",
+      "code": "value-quantity",
+			"base": "Observation",
+			"type": "number"
+    }`),
+			wants: []mvr{
+				{
+					ver: DSTU2,
+					r: &r2pb.ContainedResource{
+						OneofResource: &r2pb.ContainedResource_SearchParameter{
+							SearchParameter: &r2pb.SearchParameter{
+								Url:         &d2pb.Uri{Value: "http://example.com/SearchParameter"},
+								Name:        &d2pb.String{Value: "Search-parameter"},
+								Status:      &c2pb.ConformanceResourceStatusCode{Value: c2pb.ConformanceResourceStatusCode_ACTIVE},
+								Description: &d2pb.String{Value: "custom search parameter"},
+								Code:        &d2pb.Code{Value: "value-quantity"},
+								Base:        &c2pb.ResourceTypeCode{Value: c2pb.ResourceTypeCode_OBSERVATION},
+								Type:        &c2pb.SearchParamTypeCode{Value: c2pb.SearchParamTypeCode_NUMBER},
+							},
+						},
+					},
+				},
+			},
+		},
 		{
 			name: "R3/R4 SearchParameter",
 			json: []byte(`

--- a/go/jsonformat/unmarshaller_test.go
+++ b/go/jsonformat/unmarshaller_test.go
@@ -19,10 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	c2pb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/codes_go_proto"
-	d2pb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/datatypes_go_proto"
-	r2pb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/resources_go_proto"
-
 	"math"
 	"strconv"
 	"strings"
@@ -36,6 +32,11 @@ import (
 
 	anypb "google.golang.org/protobuf/types/known/anypb"
 
+	protov1 "github.com/golang/protobuf/proto"
+	c2pb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/codes_go_proto"
+	d2pb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/datatypes_go_proto"
+	m2pb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/metadatatypes_go_proto"
+	r2pb "github.com/google/fhir/go/proto/google/fhir/proto/dstu2/resources_go_proto"
 	c4pb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/codes_go_proto"
 	d4pb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/datatypes_go_proto"
 	r4pb "github.com/google/fhir/go/proto/google/fhir/proto/r4/core/resources/bundle_and_contained_resource_go_proto"
@@ -47,7 +48,6 @@ import (
 	d3pb "github.com/google/fhir/go/proto/google/fhir/proto/stu3/datatypes_go_proto"
 	m3pb "github.com/google/fhir/go/proto/google/fhir/proto/stu3/metadatatypes_go_proto"
 	r3pb "github.com/google/fhir/go/proto/google/fhir/proto/stu3/resources_go_proto"
-	protov1 "github.com/golang/protobuf/proto"
 )
 
 var (
@@ -173,6 +173,28 @@ func TestUnmarshal(t *testing.T) {
     }`),
 			wants: []mvr{
 				{
+					ver: DSTU2,
+					r: &r2pb.ContainedResource{
+						OneofResource: &r2pb.ContainedResource_Observation{
+							Observation: &r2pb.Observation{
+								Id: &d2pb.Id{
+									Value: "example",
+								},
+								Status: &c2pb.ObservationStatusCode{Value: c2pb.ObservationStatusCode_FINAL},
+								Code:   &d2pb.CodeableConcept{Text: &d2pb.String{Value: "test"}},
+								Text: &m2pb.Narrative{
+									Status: &c2pb.NarrativeStatusCode{
+										Value: c2pb.NarrativeStatusCode_GENERATED,
+									},
+									Div: &d2pb.Xhtml{
+										Value: `<div xmlns="http://www.w3.org/1999/xhtml">[Put rendering here]</div>`,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
 					ver: STU3,
 					r: &r3pb.ContainedResource{
 						OneofResource: &r3pb.ContainedResource_Observation{
@@ -226,6 +248,18 @@ func TestUnmarshal(t *testing.T) {
       "multipleBirthBoolean": false
     }`),
 			wants: []mvr{
+				{
+					ver: DSTU2,
+					r: &r2pb.ContainedResource{
+						OneofResource: &r2pb.ContainedResource_Patient{
+							Patient: &r2pb.Patient{
+								MultipleBirth: &r2pb.Patient_MultipleBirth{
+									MultipleBirth: &r2pb.Patient_MultipleBirth_Boolean{
+										Boolean: &d2pb.Boolean{Value: false}}},
+							},
+						},
+					},
+				},
 				{
 					ver: STU3,
 					r: &r3pb.ContainedResource{

--- a/go/jsonformat/version_config.go
+++ b/go/jsonformat/version_config.go
@@ -27,6 +27,7 @@ type Version string
 
 // FHIR converter versions.
 const (
+	DSTU2 = Version("DSTU2")
 	STU3  = Version("STU3")
 	R4    = Version("R4")
 )
@@ -48,6 +49,8 @@ type config interface {
 // getConfig returns the converter config for the given FHIR version.
 func getConfig(ver Version) (config, error) {
 	switch ver {
+	case DSTU2:
+		return dstu2Config{}, nil
 	case STU3:
 		return r3Config{}, nil
 	case R4:


### PR DESCRIPTION
This PR adds support for DSTU2 in the jsonformat package. 

Looking for comment on wether this PR has a chance of being merged at some point, thanks! 
If positive I intend to amend the PR with additional test code for the DSTU2 paths.

