### PR TITLE
Don't require backports.zoneinfo on Python 3.9 and later

### DIFF
--- a/py/google/fhir/BUILD
+++ b/py/google/fhir/BUILD
@@ -24,7 +24,7 @@ py_library(
         "@com_google_protobuf//:protobuf_python",
         "//py",
         "//py/google/fhir/utils:proto_utils",
-        requirement("backports.zoneinfo"),
+        requirement("backports.zoneinfo; python_version < '3.9'"),
         requirement("python-dateutil"),
         requirement("six"),
     ],

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,4 +1,4 @@
 absl-py~=0.10.0
-backports.zoneinfo~=0.2.1
+backports.zoneinfo~=0.2.1; python_version < '3.9'
 protobuf~=3.13.0
 python-dateutil~=2.8.1


### PR DESCRIPTION
backports.zoneinfo can't be installed without compiling on Python 3.9+: https://github.com/pganssle/zoneinfo/issues/105
