### PR TITLE
Switch all std::string_view to absl::string_view.

### DIFF
--- a/cc/google/fhir/error_reporter.h
+++ b/cc/google/fhir/error_reporter.h
@@ -87,8 +87,8 @@ class ErrorHandler {
   // * field_path: Path to the field where the error occurred.  This will be
   //               identical to `element_path`, but without the field index.
   virtual absl::Status HandleFhirFatal(const absl::Status& status,
-                                       std::string_view element_path,
-                                       std::string_view field_path) = 0;
+                                       absl::string_view element_path,
+                                       absl::string_view field_path) = 0;
 
   // Handles an "Error" issue encountered.
   // This should be used when user data violates a precondition.  For instance,
@@ -105,9 +105,9 @@ class ErrorHandler {
   //                 (including index into repeated fields).
   // * field_path: Path to the field where the error occurred.  This will be
   //               identical to `element_path`, but without the field index.
-  virtual absl::Status HandleFhirError(std::string_view msg,
-                                       std::string_view element_path,
-                                       std::string_view field_path) = 0;
+  virtual absl::Status HandleFhirError(absl::string_view msg,
+                                       absl::string_view element_path,
+                                       absl::string_view field_path) = 0;
 
   // Handles a "Warning" issue encountered.
   // This should be used when user data violates a precondition at "Warning"
@@ -122,9 +122,9 @@ class ErrorHandler {
   //                 (including index into repeated fields).
   // * field_path: Path to the field where the warning occurred.  This will be
   //               identical to `element_path`, but without the field index.
-  virtual absl::Status HandleFhirWarning(std::string_view msg,
-                                         std::string_view element_path,
-                                         std::string_view field_path) = 0;
+  virtual absl::Status HandleFhirWarning(absl::string_view msg,
+                                         absl::string_view element_path,
+                                         absl::string_view field_path) = 0;
 
   // Handles a "Fatal" issue encountered during FHIRPath evaluation.
   // This indicates a process encountered a code error (e.g., a function call
@@ -142,9 +142,9 @@ class ErrorHandler {
   // * field_path: Path to the field where the error occurred.  This will be
   //               identical to `element_path`, but without the field index.
   virtual absl::Status HandleFhirPathFatal(const absl::Status& status,
-                                           std::string_view expression,
-                                           std::string_view element_path,
-                                           std::string_view field_path) = 0;
+                                           absl::string_view expression,
+                                           absl::string_view element_path,
+                                           absl::string_view field_path) = 0;
 
   // Handles an "Error" issue encountered during FHIRPath evaluation.
   // This indicates an Error-level FHIRPath requirement that was not met by a
@@ -157,9 +157,9 @@ class ErrorHandler {
   //                 (including index into repeated fields).
   // * field_path: Path to the field where the error occurred.  This will be
   //               identical to `element_path`, but without the field index.
-  virtual absl::Status HandleFhirPathError(std::string_view expression,
-                                           std::string_view element_path,
-                                           std::string_view field_path) = 0;
+  virtual absl::Status HandleFhirPathError(absl::string_view expression,
+                                           absl::string_view element_path,
+                                           absl::string_view field_path) = 0;
 
   // Handles a "Warning" issue encountered during FHIRPath evaluation.
   // This indicates a Warning-level FHIRPath requirement that was not met by a
@@ -172,9 +172,9 @@ class ErrorHandler {
   //                 (including index into repeated fields).
   // * field_path: Path to the field where the error occurred.  This will be
   //               identical to `element_path`, but without the field index.
-  virtual absl::Status HandleFhirPathWarning(std::string_view expression,
-                                             std::string_view element_path,
-                                             std::string_view field_path) = 0;
+  virtual absl::Status HandleFhirPathWarning(absl::string_view expression,
+                                             absl::string_view element_path,
+                                             absl::string_view field_path) = 0;
 
   // Returns true if any issues have been reported at WARNING level.
   virtual bool HasWarnings() const = 0;
@@ -343,8 +343,8 @@ class FailFastErrorHandler : public ErrorHandler {
   bool HasFatals() const override { return false; }
 
   absl::Status HandleFhirFatal(const absl::Status& status,
-                               std::string_view element_path,
-                               std::string_view field_path) override {
+                               absl::string_view element_path,
+                               absl::string_view field_path) override {
     return element_path.empty()
                ? status
                : absl::Status(
@@ -352,9 +352,9 @@ class FailFastErrorHandler : public ErrorHandler {
                      absl::StrCat(status.message(), " at ", element_path));
   }
 
-  absl::Status HandleFhirError(std::string_view msg,
-                               std::string_view element_path,
-                               std::string_view field_path) override {
+  absl::Status HandleFhirError(absl::string_view msg,
+                               absl::string_view element_path,
+                               absl::string_view field_path) override {
     if (behavior_ != FAIL_ON_ERROR_OR_FATAL) {
       return absl::OkStatus();
     }
@@ -363,34 +363,34 @@ class FailFastErrorHandler : public ErrorHandler {
                                       absl::StrCat(msg, " at ", element_path));
   }
 
-  absl::Status HandleFhirWarning(std::string_view msg,
-                                 std::string_view element_path,
-                                 std::string_view field_path) override {
+  absl::Status HandleFhirWarning(absl::string_view msg,
+                                 absl::string_view element_path,
+                                 absl::string_view field_path) override {
     return absl::OkStatus();
   }
 
   absl::Status HandleFhirPathFatal(const absl::Status& status,
-                                   std::string_view expression,
-                                   std::string_view element_path,
-                                   std::string_view field_path) override {
+                                   absl::string_view expression,
+                                   absl::string_view element_path,
+                                   absl::string_view field_path) override {
     return absl::Status(
         status.code(),
         absl::Substitute("Error evaluating FHIRPath expression `$0`: $1 at $2",
                          expression, status.message(), element_path));
   }
 
-  absl::Status HandleFhirPathError(std::string_view expression,
-                                   std::string_view element_path,
-                                   std::string_view field_path) override {
+  absl::Status HandleFhirPathError(absl::string_view expression,
+                                   absl::string_view element_path,
+                                   absl::string_view field_path) override {
     return behavior_ == FAIL_ON_ERROR_OR_FATAL
                ? absl::InvalidArgumentError(absl::Substitute(
                      "Failed expression `$0` at $1", expression, element_path))
                : absl::OkStatus();
   }
 
-  absl::Status HandleFhirPathWarning(std::string_view expression,
-                                     std::string_view element_path,
-                                     std::string_view field_path) override {
+  absl::Status HandleFhirPathWarning(absl::string_view expression,
+                                     absl::string_view element_path,
+                                     absl::string_view field_path) override {
     return absl::OkStatus();
   }
 

--- a/cc/google/fhir/fhir_path/fhir_path_validation.cc
+++ b/cc/google/fhir/fhir_path/fhir_path_validation.cc
@@ -74,48 +74,48 @@ class ValidationResultsErrorHandler : public ErrorHandler {
     return ValidationResults(results_);
   }
   absl::Status HandleFhirPathFatal(const absl::Status& status,
-                                   std::string_view expression,
-                                   std::string_view element_path,
-                                   std::string_view field_path) override {
+                                   absl::string_view expression,
+                                   absl::string_view element_path,
+                                   absl::string_view field_path) override {
     results_.push_back(
         ValidationResult(field_path, element_path, expression, status));
     return absl::OkStatus();
   }
 
-  absl::Status HandleFhirPathError(std::string_view expression,
-                                   std::string_view element_path,
-                                   std::string_view field_path) override {
+  absl::Status HandleFhirPathError(absl::string_view expression,
+                                   absl::string_view element_path,
+                                   absl::string_view field_path) override {
     results_.push_back(
         ValidationResult(field_path, element_path, expression, false));
     return absl::OkStatus();
   }
 
-  absl::Status HandleFhirPathWarning(std::string_view msg,
-                                     std::string_view element_path,
-                                     std::string_view field_path) override {
+  absl::Status HandleFhirPathWarning(absl::string_view msg,
+                                     absl::string_view element_path,
+                                     absl::string_view field_path) override {
     // Legacy FHIRPath API does not support warnings.
     return absl::OkStatus();
   }
 
   absl::Status HandleFhirFatal(const absl::Status& status,
-                               std::string_view element_path,
-                               std::string_view field_path) override {
+                               absl::string_view element_path,
+                               absl::string_view field_path) override {
     return absl::InternalError(
         "ValidationResultsErrorHandler should only use FHIRPath APIs.");
     return absl::OkStatus();
   }
 
-  absl::Status HandleFhirError(std::string_view msg,
-                               std::string_view element_path,
-                               std::string_view field_path) override {
+  absl::Status HandleFhirError(absl::string_view msg,
+                               absl::string_view element_path,
+                               absl::string_view field_path) override {
     return absl::InternalError(
         "ValidationResultsErrorHandler should only use FHIRPath APIs.");
     return absl::OkStatus();
   }
 
-  absl::Status HandleFhirWarning(std::string_view msg,
-                                 std::string_view element_path,
-                                 std::string_view field_path) override {
+  absl::Status HandleFhirWarning(absl::string_view msg,
+                                 absl::string_view element_path,
+                                 absl::string_view field_path) override {
     return absl::InternalError(
         "ValidationResultsErrorHandler should only use FHIRPath APIs.");
     return absl::OkStatus();

--- a/cc/google/fhir/operation_error_reporter.h
+++ b/cc/google/fhir/operation_error_reporter.h
@@ -93,47 +93,47 @@ class OutcomeErrorHandler : public ErrorHandler {
   bool HasFatals() const override { return !GetFatals().empty(); }
 
   absl::Status HandleFhirFatal(const absl::Status& status,
-                               std::string_view element_path,
-                               std::string_view field_path) override {
+                               absl::string_view element_path,
+                               absl::string_view field_path) override {
     Handle(status.message(), IssueTypeCode::STRUCTURE, IssueSeverityCode::FATAL,
            element_path);
     return absl::OkStatus();
   };
 
-  absl::Status HandleFhirError(std::string_view msg,
-                               std::string_view element_path,
-                               std::string_view field_path) override {
+  absl::Status HandleFhirError(absl::string_view msg,
+                               absl::string_view element_path,
+                               absl::string_view field_path) override {
     Handle(msg, IssueTypeCode::VALUE, IssueSeverityCode::ERROR, element_path);
     return absl::OkStatus();
   };
 
-  absl::Status HandleFhirWarning(std::string_view msg,
-                                 std::string_view element_path,
-                                 std::string_view field_path) override {
+  absl::Status HandleFhirWarning(absl::string_view msg,
+                                 absl::string_view element_path,
+                                 absl::string_view field_path) override {
     Handle(msg, IssueTypeCode::VALUE, IssueSeverityCode::WARNING, element_path);
     return absl::OkStatus();
   };
 
   absl::Status HandleFhirPathFatal(const absl::Status& status,
-                                   std::string_view expression,
-                                   std::string_view element_path,
-                                   std::string_view field_path) override {
+                                   absl::string_view expression,
+                                   absl::string_view element_path,
+                                   absl::string_view field_path) override {
     Handle(absl::StrCat(expression, ":", status.message()),
            IssueTypeCode::STRUCTURE, IssueSeverityCode::FATAL, element_path);
     return absl::OkStatus();
   };
 
-  absl::Status HandleFhirPathError(std::string_view expression,
-                                   std::string_view element_path,
-                                   std::string_view field_path) override {
+  absl::Status HandleFhirPathError(absl::string_view expression,
+                                   absl::string_view element_path,
+                                   absl::string_view field_path) override {
     Handle(expression, IssueTypeCode::VALUE, IssueSeverityCode::ERROR,
            element_path);
     return absl::OkStatus();
   };
 
-  absl::Status HandleFhirPathWarning(std::string_view expression,
-                                     std::string_view element_path,
-                                     std::string_view field_path) override {
+  absl::Status HandleFhirPathWarning(absl::string_view expression,
+                                     absl::string_view element_path,
+                                     absl::string_view field_path) override {
     Handle(expression, IssueTypeCode::VALUE, IssueSeverityCode::WARNING,
            element_path);
     return absl::OkStatus();


### PR DESCRIPTION
absl:string_view is recommended over std::string_view and avoid emscripten compliation error on string conversion (web assembly).