### PR TITLE
add missing normalize ref

### DIFF
--- a/go/jsonformat/reference.go
+++ b/go/jsonformat/reference.go
@@ -94,6 +94,8 @@ func NormalizeReference(pb proto.Message) error {
 		return normalizeR3Reference(ref)
 	case *d4pb.Reference:
 		return normalizeR4Reference(ref)
+	case *d5pb.Reference:
+		return normalizeR5Reference(ref)
 	default:
 		return fmt.Errorf("invalid reference type %T", ref)
 	}


### PR DESCRIPTION
Thank you for the quick response last time. May you please expose these 2 missing lines as well? The R5 jsonformat unmarshaller errs on valid references without this.