### PR TITLE
Update deprecated GitHub Help link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,5 +19,5 @@ again.
 
 All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose. Consult
-[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+[GitHub Help](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for more
 information on using pull requests.


### PR DESCRIPTION
## Problem
The CONTRIBUTING.md file links to https://help.github.com/articles/about-pull-requests/, which GitHub has deprecated and redirected to a generic help landing page. The link no longer points at the intended documentation about pull requests.

## Change
Update the link to the current official GitHub documentation: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests

## Why this is safe
This is a documentation-only, one-line change to a URL in a Markdown file. It does not touch any code, build configuration, or generated FHIR protos. The new URL is the canonical, actively maintained destination on docs.github.com.

## Verification
The new URL resolves to the GitHub documentation page about pull requests. No code or build artifacts are affected.